### PR TITLE
Listen on 0.0.0.0 in dev

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+  },
 });


### PR DESCRIPTION
## Summary
- allow vite dev server to listen on all interfaces so `npm run dev` is reachable externally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852b8da76788331a54f8bb0ab27c909