### PR TITLE
Implement simple subscription manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Subsc Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -2,41 +2,4 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,9 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import SubscriptionManager from './components/SubscriptionManager.jsx'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <SubscriptionManager />
   )
 }
 

--- a/src/components/SubscriptionManager.css
+++ b/src/components/SubscriptionManager.css
@@ -1,0 +1,28 @@
+.subsc-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+.subsc-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.subsc-form input,
+.subsc-form select {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.subsc-list {
+  list-style: none;
+  padding: 0;
+}
+
+.subsc-list li {
+  margin: 0.25rem 0;
+}

--- a/src/components/SubscriptionManager.jsx
+++ b/src/components/SubscriptionManager.jsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react'
+import './SubscriptionManager.css'
+
+function SubscriptionManager() {
+  const [subscriptions, setSubscriptions] = useState([])
+  const [name, setName] = useState('')
+  const [price, setPrice] = useState('')
+  const [currency, setCurrency] = useState('JPY')
+  const [billingCycle, setBillingCycle] = useState('monthly')
+  const [exchangeRate, setExchangeRate] = useState(null)
+
+  useEffect(() => {
+    if (currency === 'USD') {
+      fetch('https://open.er-api.com/v6/latest/USD')
+        .then(res => res.json())
+        .then(data => setExchangeRate(data.rates.JPY))
+        .catch(() => {})
+    }
+  }, [currency])
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    let jpyPrice = parseFloat(price)
+    if (currency === 'USD' && exchangeRate) {
+      jpyPrice = parseFloat(price) * exchangeRate
+    }
+    const newSub = {
+      name,
+      price: parseFloat(price),
+      currency,
+      billingCycle,
+      jpyPrice,
+    }
+    setSubscriptions([...subscriptions, newSub])
+    setName('')
+    setPrice('')
+  }
+
+  return (
+    <div className="subsc-container">
+      <h1>Subscription Manager</h1>
+      <form onSubmit={handleSubmit} className="subsc-form">
+        <input
+          type="text"
+          placeholder="Service name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Price"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          required
+        />
+        <select value={currency} onChange={(e) => setCurrency(e.target.value)}>
+          <option value="JPY">JPY</option>
+          <option value="USD">USD</option>
+        </select>
+        <select
+          value={billingCycle}
+          onChange={(e) => setBillingCycle(e.target.value)}
+        >
+          <option value="monthly">Monthly</option>
+          <option value="yearly">Yearly</option>
+        </select>
+        <button type="submit">Add</button>
+      </form>
+      <ul className="subsc-list">
+        {subscriptions.map((sub, idx) => (
+          <li key={idx}>
+            {sub.name}: {sub.price} {sub.currency} ({sub.billingCycle})
+            {sub.currency === 'USD' && exchangeRate && (
+              <span> → {sub.jpyPrice.toFixed(0)} JPY</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default SubscriptionManager


### PR DESCRIPTION
## Summary
- add SubscriptionManager component for entering services in JPY or USD
- convert USD to JPY via exchange rate API
- simplify App to render the new manager
- add basic modern styling
- change the page title

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bce9c084833193c7300a09d6a58f